### PR TITLE
Update membership check URL

### DIFF
--- a/frontend/src/components/MembershipChecker/MembershipChecker.tsx
+++ b/frontend/src/components/MembershipChecker/MembershipChecker.tsx
@@ -67,7 +67,7 @@ function MembershipChecker() {
             return
         }
         setIsCheckingPersonalId(true)
-        UtnMembership.post<UtnMembershipResponse>('/member_check/check_membership.php', `ssn=${personalId}`)
+        UtnMembership.post<UtnMembershipResponse>('/member_check/member_check_api', `ssn=${personalId}`)
             .then(response => {
                 setPersonalId('')
                 setIsMember(response.data.is_member)


### PR DESCRIPTION
Changes the membership check URL. Might cause CORS header issues in production, but assuming nothing has changed other than the URL, then it shouldn't have to be more complicated than this.