### PR TITLE
Make admin pages the starting site

### DIFF
--- a/ordsys/urls.py
+++ b/ordsys/urls.py
@@ -19,6 +19,6 @@ from django.urls import path, include
 
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path('', admin.site.urls),
     path('', include('backend.urls')),
 ]


### PR DESCRIPTION
When you go to ordsysbackend.utn.se you always have to go to `/admin`. It's easier to just go to the startpage and have the admin there right away