### PR TITLE
Switch url patterns

### DIFF
--- a/ordsys/urls.py
+++ b/ordsys/urls.py
@@ -18,6 +18,7 @@ from django.urls import path, include
 
 
 urlpatterns = [
-    path('', admin.site.urls),
     path('', include('backend.urls')),
+    path('', admin.site.urls),
+   
 ]

--- a/ordsys/urls.py
+++ b/ordsys/urls.py
@@ -20,5 +20,4 @@ from django.urls import path, include
 urlpatterns = [
     path('', include('backend.urls')),
     path('', admin.site.urls),
-   
 ]


### PR DESCRIPTION
Django was reading URL patterns top-down, which caused a 404 error when trying to access the backends /api/ page. By changing the ordering and moving the backend URLs to the top, this issue is fixed.