### PR TITLE
Change bulk_save to normal save

### DIFF
--- a/backend/serializers.py
+++ b/backend/serializers.py
@@ -107,7 +107,6 @@ class CreatableOrderWithOrderItemsSerializer(BaseOrderWithOrderItemsSerializer):
         )
         order_items = validated_data.pop('order_items')
 
-
         # We want to avoid sending a post_save signal before all
         # OrderItems are created, otherwise duplicate orders would
         # appear on the front-end until the page is refreshed.


### PR DESCRIPTION
Due to a recent Django update (presumably), the previously way of using bulk_save to save Orders and OrderItems together is no longer working.

This pull request change the system to instead use a normal save. This would have caused duplicate orders to appear in the frontend, so a manual way of preventing post_save signals was implemented as well.