### PR TITLE
Add permissions to staff

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -215,6 +215,9 @@ class UserAdmin(BaseUserAdmin, ForeignKeyModelAdmin):
                 (None, {
                     'fields': ['username', 'password', 'confirm_password']
                 }),
+                ('Permissions', {
+                    'fields': ['is_staff', 'groups']
+                }),
             )
         return (
             (None, {


### PR DESCRIPTION
Adds permission to regular admin users (not superusers) allowing them to create staff accounts.

Fixes #107 