### PR TITLE
Make claim and deliver not mutually exclusive

### DIFF
--- a/frontend/src/components/Bar/OrderDetail.tsx
+++ b/frontend/src/components/Bar/OrderDetail.tsx
@@ -38,22 +38,21 @@ function OrderDetail({
                         {order.status}
                     </OrderTicket>
                 </div>
-                {order.status !== OrderStatus.IN_TRANSIT ?
+                {order.status !== OrderStatus.IN_TRANSIT &&
                     <Button className="btn-info detail-view-button" onClick={() => claimOrder(order.id)}>
-                        Claim
-                    </Button> :
-                    <Button className="btn-success detail-view-button" onClick={() => deliverOrder(order.id)}>
-                        Deliver
+                        Mark as claimed
                     </Button>
                 }
-                { editOrder ?
+                <Button className="btn-success detail-view-button" onClick={() => deliverOrder(order.id)}>
+                        Mark as delivered
+                </Button>
+                { editOrder &&
                     <Button className="btn-secondary detail-view-button" onClick={() => editOrder(order)}>
-                        Edit
-                    </Button> :
-                    null
+                        Edit order
+                    </Button>
                 }
                 <Button className="btn-danger detail-view-button" onClick={() => deleteOrder(order.id)}>
-                    Delete
+                    Delete order
                 </Button>
             </div>
         </Modal>


### PR DESCRIPTION
Changes the order detail modal to display "deliver order" and
"claim order" simultaneously. Also changes the button text to more descriptive than their previous one word text and updates the typescript if:s to not need an else.

Previously, you could only mark claimed orders as delivered. While this does work well with the runner volunteer concept used at some events, it adds an annoying extra step when not using runners, meaning bar staff has to claim and then immediately deliver an order.

![image](https://user-images.githubusercontent.com/10797498/126615769-095a59ed-78b6-4bd9-a994-b4e55d782220.png)
