### PR TITLE
Properly setup the proxy middleware

### DIFF
--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -2,8 +2,7 @@ const createProxyMiddleware = require('http-proxy-middleware');
 
 module.exports = function (app) {
     app.use(
-        '/admin',
-        createProxyMiddleware({
+        createProxyMiddleware('/admin', {
             target: 'http://localhost:8000',
             changeOrigin: true,
             ws: true


### PR DESCRIPTION
By incorrectly setting the proxy, the webpack development server hot reload websocket requests are sent to the backend.