### PR TITLE
Fix jumping pickup view

### DIFF
--- a/frontend/src/components/Pickup/Pickup.scss
+++ b/frontend/src/components/Pickup/Pickup.scss
@@ -1,5 +1,5 @@
 .bar-top.row {
-    height: 6.5vh;
+    height: auto;
 
     h3 {
         font-family: "TeXGyreAdventorBold", sans-serif;
@@ -10,4 +10,8 @@
 .row.menu {
     flex: 0 3 75%;
     overflow-y: auto;
+}
+
+.pickup-main-container {
+    max-width: 100%; // Remove bootstraps default max width
 }

--- a/frontend/src/components/Pickup/Pickup.tsx
+++ b/frontend/src/components/Pickup/Pickup.tsx
@@ -79,7 +79,7 @@ function Pickup() {
 
 
     return (
-        <>
+        <Container className="pickup-main-container">
             <Row xs={2} className="bar-top">
                 <Col xs={7} className="my-2 justify-content-center">
                     <h3 className="pr-2 pt-2 align-self-center">IN PROGRESS</h3>
@@ -106,7 +106,7 @@ function Pickup() {
                     </Container>
                 </Col>
             </Row>
-        </>
+        </Container>
     )
 }
 


### PR DESCRIPTION
The pickup view changes it size every second. It appears a missing container was the issue