### PR TITLE
Properly set font-faces

### DIFF
--- a/frontend/src/components/App.scss
+++ b/frontend/src/components/App.scss
@@ -12,14 +12,14 @@
       color: inherit;
 
       & .MuiButton-label {
-        font-family: "TexGyreAdventorRegular", sans-serif;
+        font-family: "TexGyreAdventor", sans-serif;
         font-size: 1.2em;
         margin-bottom: 1px;
       }
     }
   }
   & .SnackbarItem-message {
-    font-family: "TeXGyreAdventorRegular", sans-serif;
+    font-family: "TeXGyreAdventor", sans-serif;
     font-size: 1.4em;
     margin-bottom: 3px;
 

--- a/frontend/src/components/Bar/Bar.scss
+++ b/frontend/src/components/Bar/Bar.scss
@@ -13,7 +13,7 @@
     height: 6.5vh;
 
     h3 {
-        font-family: "TeXGyreAdventorBold", sans-serif;
+        font-weight: bold;
         text-align: center;
     }
 }

--- a/frontend/src/components/MembershipChecker/MembershipChecker.scss
+++ b/frontend/src/components/MembershipChecker/MembershipChecker.scss
@@ -14,7 +14,7 @@
         width: 97.5%;
 
         * {
-            font-family: TexGyreAdventorRegular, sans-serif;
+            font-family: TexGyreAdventor, sans-serif;
         }
     }
 }
@@ -22,5 +22,6 @@
 #personal-id-submit {
     height: 2.5rem;
     width: 97.5%;
-    font-family: TeXGyreAdventorBold, sans-serif;
+    font-family: TeXGyreAdventor, sans-serif;
+    font-weight: bold;
 }

--- a/frontend/src/components/Pickup/Pickup.scss
+++ b/frontend/src/components/Pickup/Pickup.scss
@@ -2,7 +2,7 @@
     height: auto;
 
     h3 {
-        font-family: "TeXGyreAdventorBold", sans-serif;
+        font-weight: bold;
         text-align: center;
     }
 }

--- a/frontend/src/fonts.css
+++ b/frontend/src/fonts.css
@@ -1,5 +1,5 @@
 @font-face {
-    font-family: 'TeXGyreAdventorBold';
+    font-family: 'TeXGyreAdventor';
     /*noinspection CssUnknownTarget*/
     src: url('fonts/TeXGyreAdventorBold.ttf') format('truetype');
     font-weight: bold;
@@ -7,7 +7,7 @@
 }
 
 @font-face {
-    font-family: 'TeXGyreAdventorBoldItalic';
+    font-family: 'TeXGyreAdventor';
     /*noinspection CssUnknownTarget*/
     src: url('fonts/TeXGyreAdventorBoldItalic.ttf') format('truetype');
     font-weight: bold;
@@ -15,7 +15,7 @@
 }
 
 @font-face {
-    font-family: 'TeXGyreAdventorItalic';
+    font-family: 'TeXGyreAdventor';
     /*noinspection CssUnknownTarget*/
     src: url('fonts/TeXGyreAdventorItalic.ttf') format('truetype');
     font-weight: normal;
@@ -23,7 +23,7 @@
 }
 
 @font-face {
-    font-family: 'TeXGyreAdventorRegular';
+    font-family: 'TeXGyreAdventor';
     /*noinspection CssUnknownTarget*/
     src: url('fonts/TeXGyreAdventorRegular.ttf') format('truetype');
     font-weight: normal;

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -5,7 +5,7 @@
     height: 100vh;
     display: flex;
     flex-direction: column;
-    font-family: 'TeXGyreAdventorRegular', sans-serif;
+    font-family: 'TeXGyreAdventor', sans-serif;
     -webkit-user-select: none; /* Safari */
     -moz-user-select: none; /* Firefox */
     -ms-user-select: none; /* IE10+/Edge */


### PR DESCRIPTION
Fonts should be within the same family and controlled via `font-weight`/`font-style`, not by setting a new font family to modify weight or style.