### PR TITLE
Switched to masonry component in menu

### DIFF
--- a/frontend/src/components/Bar/Bar.tsx
+++ b/frontend/src/components/Bar/Bar.tsx
@@ -360,7 +360,7 @@ function Bar({ renderMode }: BarProps) {
                             "& > input": { textAlign: "center" },
                         }}
                     />
-                    <Box sx={{overflow: "auto"}}>
+                    <Box sx={{overflowY: "auto", width: "100%"}}>
                         <Menu onMenuItemClick={onMenuItemClick} />
                     </Box>
                 </Box>

--- a/frontend/src/components/Bar/Bar.tsx
+++ b/frontend/src/components/Bar/Bar.tsx
@@ -335,7 +335,7 @@ function Bar({ renderMode }: BarProps) {
                 />
             </Column>
             <Column flex={flex}>
-                <Box marginBottom={2}>
+                <Box flex={1} flexDirection="column" display="flex" marginBottom={2} sx={{overflow: "hidden"}}>
                     <Typography
                         align="center"
                         component="h2"
@@ -360,7 +360,9 @@ function Bar({ renderMode }: BarProps) {
                             "& > input": { textAlign: "center" },
                         }}
                     />
-                    <Menu onMenuItemClick={onMenuItemClick} />
+                    <Box sx={{overflow: "auto"}}>
+                        <Menu onMenuItemClick={onMenuItemClick} />
+                    </Box>
                 </Box>
                 {isFullView
                     ? <MembershipChecker/>

--- a/frontend/src/components/Bar/Menu.tsx
+++ b/frontend/src/components/Bar/Menu.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Button, Grid, Typography } from "@mui/material";
+import { Button, Typography } from "@mui/material";
 
 import { useActiveMenuItems } from "../../hooks";
 
@@ -24,24 +24,22 @@ const Menu = memo(function Menu({ onMenuItemClick }: MenuProps) {
     return (
         <Masonry sx={{margin: 0}} spacing={2} columns={{ xs: 1, lg: 2 }}>
             {activeMenuItems.map((item) => (
-                <Grid key={item.id} item xs={1} lg={1}>
-                    <Button
-                        fullWidth
-                        onClick={() => onMenuItemClick(item)}
-                        variant="contained"
-                        size="large"
-                        sx={{
-                            padding: {
-                                xs: undefined,
-                                md: "12px",
-                                lg: "15px"
-                            },
-                            fontSize: "1.75rem"
-                        }}
-                    >
-                        {item.item_name}
-                    </Button>
-                </Grid>
+                <Button
+                    fullWidth
+                    onClick={() => onMenuItemClick(item)}
+                    variant="contained"
+                    size="large"
+                    sx={{
+                        padding: {
+                            xs: undefined,
+                            md: "12px",
+                            lg: "15px"
+                        },
+                        fontSize: "1.75rem"
+                    }}
+                >
+                    {item.item_name}
+                </Button>
             ))}
         </Masonry>
     );

--- a/frontend/src/components/Bar/Menu.tsx
+++ b/frontend/src/components/Bar/Menu.tsx
@@ -4,6 +4,7 @@ import { Button, Grid, Typography } from "@mui/material";
 import { useActiveMenuItems } from "../../hooks";
 
 import type { MenuItem } from '../../@types';
+import { Masonry } from '@mui/lab';
 
 interface MenuProps {
     onMenuItemClick: (item: MenuItem) => void
@@ -21,7 +22,7 @@ const Menu = memo(function Menu({ onMenuItemClick }: MenuProps) {
     }
 
     return (
-        <Grid paddingY={2} container spacing={2} columns={{ xs: 1, lg: 2 }}>
+        <Masonry sx={{margin: 0}} spacing={2} columns={{ xs: 1, lg: 2 }}>
             {activeMenuItems.map((item) => (
                 <Grid key={item.id} item xs={1} lg={1}>
                     <Button
@@ -42,7 +43,7 @@ const Menu = memo(function Menu({ onMenuItemClick }: MenuProps) {
                     </Button>
                 </Grid>
             ))}
-        </Grid>
+        </Masonry>
     );
 });
 


### PR DESCRIPTION
I switched out the grid component for the masonry component in the menu in the bar view to go back to how it looked previously. It can scroll and works on smaller screens as well

### Before
![Before](https://user-images.githubusercontent.com/19433606/226916440-019510b2-8576-4158-8c34-699445c6074b.png)

### After
![After](https://user-images.githubusercontent.com/19433606/226916445-250ebb78-b4a3-4ff9-9f69-66cb6238f4de.png)

### Demo showing scrolling capabilities
[OrdSys.webm](https://user-images.githubusercontent.com/19433606/226916258-fd4c4911-0186-4788-9343-462ca3e45a52.webm)

Closes #385 